### PR TITLE
Refine page metadata

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
-    <title>Micheal Breedlove | Cybersecurity Professional, Veteran, Michelin-Trained Chef & Culinary Farmer</title>
-<meta name="description" content="Micheal Breedlove – Culinary farmer and Army veteran transitioning into cybersecurity and automation. Passionate about secure systems, scripting, and solving real-world problems through technology.">
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
-        <meta name="description" content />
-        <meta name="author" content />
+        <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+        <meta
+            name="description"
+            content="Micheal Breedlove – Culinary farmer and Army veteran transitioning into cybersecurity and automation. Passionate about secure systems, scripting, and solving real-world problems through technology."
+        />
+        <meta name="author" content="Micheal Breedlove" />
         <title>Contact | Micheal Breedlove</title>
         <!-- Favicon-->
         <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />

--- a/index.html
+++ b/index.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-    <title>Micheal Breedlove | Cybersecurity Professional, Veteran, Michelin-Trained Chef & Culinary Farmer</title>
-<meta name="description" content="Micheal Breedlove – Culinary farmer and Army veteran transitioning into cybersecurity and automation. Passionate about secure systems, scripting, and solving real-world problems through technology.">
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
-        <meta name="description" content="" />
-        <meta name="author" content="" />
-        <title>Micheal Breedlove | Cybersecurity Professional & Veteran</title>
+        <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+        <meta
+            name="description"
+            content="Micheal Breedlove – Culinary farmer and Army veteran transitioning into cybersecurity and automation. Passionate about secure systems, scripting, and solving real-world problems through technology."
+        />
+        <meta name="author" content="Micheal Breedlove" />
+        <title>Micheal Breedlove | Cybersecurity Professional, Veteran, Michelin-Trained Chef &amp; Culinary Farmer</title>
         <!-- Favicon-->
         <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
         <!-- Custom Google font-->

--- a/projects.html
+++ b/projects.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
-    <title>Micheal Breedlove | Cybersecurity Professional, Veteran, Michelin-Trained Chef & Culinary Farmer</title>
-<meta name="description" content="Micheal Breedlove – Culinary farmer and Army veteran transitioning into cybersecurity and automation. Passionate about secure systems, scripting, and solving real-world problems through technology.">
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
-        <meta name="description" content="" />
-        <meta name="author" content="" />
+        <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+        <meta
+            name="description"
+            content="Micheal Breedlove – Culinary farmer and Army veteran transitioning into cybersecurity and automation. Passionate about secure systems, scripting, and solving real-world problems through technology."
+        />
+        <meta name="author" content="Micheal Breedlove" />
         <title>Projects | Micheal Breedlove</title>
         <!-- Favicon-->
         <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />

--- a/resume.html
+++ b/resume.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
-    <title>Micheal Breedlove | Cybersecurity Professional, Veteran, Michelin-Trained Chef & Culinary Farmer</title>
-<meta name="description" content="Micheal Breedlove – Culinary farmer and Army veteran transitioning into cybersecurity and automation. Passionate about secure systems, scripting, and solving real-world problems through technology.">
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
-        <meta name="description" content="" />
-        <meta name="author" content="" />
+        <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+        <meta
+            name="description"
+            content="Micheal Breedlove – Culinary farmer and Army veteran transitioning into cybersecurity and automation. Passionate about secure systems, scripting, and solving real-world problems through technology."
+        />
+        <meta name="author" content="Micheal Breedlove" />
         <title>Resume | Micheal Breedlove</title>
         <!-- Favicon-->
         <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />


### PR DESCRIPTION
## Summary
- restore the full home page title that highlights cybersecurity, veteran, chef, and farmer roles
- populate the author meta tag across every page with Micheal Breedlove's name for consistent attribution

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce2a7317a08328b47ea3c1fba620a2