### PR TITLE
Add Jasper Timeclock OAuth disclosure pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,6 +482,10 @@
                         <span class="mx-1">&middot;</span>
                         <a class="small" href="https://github.com/MichealBreedlove" target="_blank">GitHub</a>
                         <span class="mx-1">&middot;</span>
+                        <a class="small" href="/jasper-timeclock.html">Jasper Timeclock</a>
+                        <span class="mx-1">&middot;</span>
+                        <a class="small" href="/jasper-timeclock-privacy.html">Privacy</a>
+                        <span class="mx-1">&middot;</span>
                         <span class="small text-muted">Fairfield, CA</span>
                     </div>
                 </div>

--- a/jasper-timeclock-privacy.html
+++ b/jasper-timeclock-privacy.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <meta name="description" content="Privacy Policy for Jasper Timeclock MFA, including Gmail read-only access, local storage, retention, sharing, and revocation." />
+    <meta name="author" content="Micheal Breedlove" />
+    <title>Privacy Policy | Jasper Timeclock MFA</title>
+    <link rel="canonical" href="https://www.michealbreedlove.com/jasper-timeclock-privacy.html" />
+    <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&amp;display=swap" rel="stylesheet" />
+    <link href="css/styles.css" rel="stylesheet" />
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <a class="visually-hidden-focusable position-absolute top-0 start-0 m-2 p-2 bg-white rounded" href="#page-main">Skip to content</a>
+    <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
+        <div class="container px-5">
+            <a class="navbar-brand" href="/jasper-timeclock.html"><span class="fw-bolder text-primary">Jasper Timeclock MFA</span></a>
+            <div class="ms-auto d-flex gap-3 small fw-bolder">
+                <a class="nav-link" href="/jasper-timeclock.html">App information</a>
+                <a class="nav-link" href="/jasper-timeclock-terms.html">Terms</a>
+            </div>
+        </div>
+    </nav>
+    <main class="flex-grow-1" id="page-main">
+        <section class="py-5 bg-light">
+            <div class="container px-5">
+                <div class="row justify-content-center">
+                    <div class="col-lg-9 col-xl-8">
+                        <h1 class="display-5 fw-bolder mb-3"><span class="text-gradient d-inline">Privacy Policy</span></h1>
+                        <p class="text-muted mb-0">Jasper Timeclock MFA &middot; Effective August 29, 2026</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <section class="py-5">
+            <div class="container px-5">
+                <div class="row justify-content-center">
+                    <article class="col-lg-9 col-xl-8">
+                        <h2 class="h4 fw-bolder mt-2">Overview</h2>
+                        <p>Jasper Timeclock MFA is a private, locally operated automation owned by Micheal Breedlove. It uses Google OAuth solely to retrieve a recent ExponentHR multifactor-authentication email after the operator deliberately requests a code.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">Google user data accessed</h2>
+                        <p>The app requests <code>https://www.googleapis.com/auth/gmail.readonly</code>. This scope permits viewing Gmail messages and settings. The app’s implemented use is narrower: it searches for up to ten recent messages matching an ExponentHR sender and MFA-related terms, checks their timestamp, reads matching message content, and extracts a one-time verification code.</p>
+                        <p>The app does not send, modify, label, archive, or delete Gmail data.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">How Google user data is used</h2>
+                        <p>Matching message data is used only to identify the current ExponentHR verification code and complete the authentication step associated with the operator’s timeclock request. It is not used for advertising, analytics, credit decisions, profiling, or unrelated automation.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">Storage and retention</h2>
+                        <ul>
+                            <li>OAuth client configuration and the refresh token are stored in a local, git-ignored configuration file on the operator’s Windows computer.</li>
+                            <li>Fetched Gmail message content and the extracted code are processed in memory and are not intentionally written to the app’s logs or debug artifacts.</li>
+                            <li>Operational logs record success or failure events without intentionally recording the email body or MFA code.</li>
+                            <li>The refresh token is retained until it is replaced, revoked, or no longer needed.</li>
+                        </ul>
+
+                        <h2 class="h4 fw-bolder mt-5">Sharing and transfer</h2>
+                        <p>Google user data is not sold, rented, shared with advertisers, or disclosed to data brokers. The app communicates directly with Google’s OAuth and Gmail API endpoints from the operator’s local computer. The extracted one-time code is supplied only to ExponentHR for the authentication flow that caused the code to be sent.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">Security</h2>
+                        <p>Access is limited to the operator’s local Windows account and the minimum OAuth scope used by the workflow. Secret configuration is excluded from version control. The automation fails closed if OAuth refresh, MFA retrieval, login state, or page state is uncertain.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">Revoking access</h2>
+                        <p>The operator can revoke the app’s Google access at any time from <a href="https://myaccount.google.com/connections" target="_blank" rel="noopener">Google Account third-party connections</a>. Revocation prevents future Gmail API access until a new authorization is granted.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">Google API Services User Data Policy</h2>
+                        <p>Jasper Timeclock MFA’s use and transfer of information received from Google APIs adheres to the <a href="https://developers.google.com/terms/api-services-user-data-policy" target="_blank" rel="noopener">Google API Services User Data Policy</a>, including its Limited Use requirements.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">Changes</h2>
+                        <p>This policy will be updated if the app’s data access or handling changes. The effective date above identifies the current version.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">Contact</h2>
+                        <p>Questions about this policy or Google data handling may be sent to <a href="mailto:mikejohnbreedlove@gmail.com">the app operator</a>.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+    <footer class="bg-white py-4 mt-auto">
+        <div class="container px-5 d-flex flex-wrap justify-content-between gap-2 small">
+            <span>Copyright &copy; Micheal Breedlove 2026</span>
+            <span><a href="/jasper-timeclock.html">App information</a> &middot; <a href="/jasper-timeclock-terms.html">Terms</a> &middot; <a href="/contact.html">Contact</a></span>
+        </div>
+    </footer>
+</body>
+</html>

--- a/jasper-timeclock-terms.html
+++ b/jasper-timeclock-terms.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <meta name="description" content="Terms of Use for Jasper Timeclock MFA, a private local ExponentHR authentication helper." />
+    <meta name="author" content="Micheal Breedlove" />
+    <title>Terms of Use | Jasper Timeclock MFA</title>
+    <link rel="canonical" href="https://www.michealbreedlove.com/jasper-timeclock-terms.html" />
+    <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&amp;display=swap" rel="stylesheet" />
+    <link href="css/styles.css" rel="stylesheet" />
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <a class="visually-hidden-focusable position-absolute top-0 start-0 m-2 p-2 bg-white rounded" href="#page-main">Skip to content</a>
+    <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
+        <div class="container px-5">
+            <a class="navbar-brand" href="/jasper-timeclock.html"><span class="fw-bolder text-primary">Jasper Timeclock MFA</span></a>
+            <div class="ms-auto d-flex gap-3 small fw-bolder">
+                <a class="nav-link" href="/jasper-timeclock.html">App information</a>
+                <a class="nav-link" href="/jasper-timeclock-privacy.html">Privacy</a>
+            </div>
+        </div>
+    </nav>
+    <main class="flex-grow-1" id="page-main">
+        <section class="py-5 bg-light">
+            <div class="container px-5">
+                <div class="row justify-content-center">
+                    <div class="col-lg-9 col-xl-8">
+                        <h1 class="display-5 fw-bolder mb-3"><span class="text-gradient d-inline">Terms of Use</span></h1>
+                        <p class="text-muted mb-0">Jasper Timeclock MFA &middot; Effective August 29, 2026</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <section class="py-5">
+            <div class="container px-5">
+                <div class="row justify-content-center">
+                    <article class="col-lg-9 col-xl-8">
+                        <h2 class="h4 fw-bolder">Purpose and availability</h2>
+                        <p>Jasper Timeclock MFA is a private, personal-use automation operated by Micheal Breedlove. It is not offered as a public timekeeping, payroll, email, or authentication service.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">Authorized use</h2>
+                        <p>The app may be used only by the operator with accounts and data the operator is authorized to access. It must not be used to bypass employer policy, impersonate another person, or access another person’s Google or ExponentHR account.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">Timekeeping safeguards</h2>
+                        <p>The app is designed to fail closed when authentication, account status, MFA retrieval, schedule authorization, page controls, or post-action state is uncertain. It does not guarantee that a scheduled timeclock action will occur, and it must not be treated as a substitute for reviewing official payroll records.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">Google services</h2>
+                        <p>Use of Google services remains subject to Google’s applicable terms and policies. Google access may be revoked at any time, which will stop the app from retrieving MFA messages.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">No warranty</h2>
+                        <p>The app is provided for the operator’s personal use without warranties of uninterrupted availability or fitness for a particular purpose. The operator remains responsible for confirming attendance, punches, and payroll records with the employer.</p>
+
+                        <h2 class="h4 fw-bolder mt-5">Contact</h2>
+                        <p>Questions may be sent to <a href="mailto:mikejohnbreedlove@gmail.com">the app operator</a>.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+    <footer class="bg-white py-4 mt-auto">
+        <div class="container px-5 d-flex flex-wrap justify-content-between gap-2 small">
+            <span>Copyright &copy; Micheal Breedlove 2026</span>
+            <span><a href="/jasper-timeclock.html">App information</a> &middot; <a href="/jasper-timeclock-privacy.html">Privacy</a> &middot; <a href="/contact.html">Contact</a></span>
+        </div>
+    </footer>
+</body>
+</html>

--- a/jasper-timeclock.html
+++ b/jasper-timeclock.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+    <meta name="description" content="Jasper Timeclock MFA is a private, local automation that reads recent ExponentHR MFA emails through Gmail read-only access." />
+    <meta name="author" content="Micheal Breedlove" />
+    <title>Jasper Timeclock MFA | App Information</title>
+    <link rel="canonical" href="https://www.michealbreedlove.com/jasper-timeclock.html" />
+    <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&amp;display=swap" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet" />
+    <link href="css/styles.css" rel="stylesheet" />
+</head>
+<body class="d-flex flex-column min-vh-100">
+    <a class="visually-hidden-focusable position-absolute top-0 start-0 m-2 p-2 bg-white rounded" href="#page-main">Skip to content</a>
+    <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
+        <div class="container px-5">
+            <a class="navbar-brand" href="/index.html"><span class="fw-bolder text-primary">Micheal Breedlove</span></a>
+            <div class="ms-auto d-flex gap-3 small fw-bolder">
+                <a class="nav-link" href="/jasper-timeclock-privacy.html">Privacy</a>
+                <a class="nav-link" href="/jasper-timeclock-terms.html">Terms</a>
+            </div>
+        </div>
+    </nav>
+    <main class="flex-grow-1" id="page-main">
+        <section class="py-5 bg-light">
+            <div class="container px-5">
+                <div class="row justify-content-center">
+                    <div class="col-lg-9 col-xl-8">
+                        <p class="text-uppercase small fw-semibold text-muted mb-2" style="letter-spacing:0.08em;">Private local automation</p>
+                        <h1 class="display-5 fw-bolder mb-3"><span class="text-gradient d-inline">Jasper Timeclock MFA</span></h1>
+                        <p class="lead text-muted">A personal safety-focused helper that retrieves a recent ExponentHR one-time verification code from Gmail after an MFA request.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <section class="py-5">
+            <div class="container px-5">
+                <div class="row justify-content-center">
+                    <div class="col-lg-9 col-xl-8">
+                        <div class="card shadow border-0 rounded-4 mb-4">
+                            <div class="card-body p-4 p-lg-5">
+                                <h2 class="h3 fw-bolder">What the app does</h2>
+                                <p>Jasper Timeclock MFA runs on the operator’s Windows computer as part of a private ExponentHR timeclock workflow. When ExponentHR requests multifactor authentication, the app searches for a recent message from <code>exponenthr.com</code>, reads the matching message, extracts the one-time code, and uses that code only to complete the requested authentication step.</p>
+                                <p class="mb-0">The app is not a general email client and is not offered as a public service.</p>
+                            </div>
+                        </div>
+                        <div class="card shadow border-0 rounded-4 mb-4">
+                            <div class="card-body p-4 p-lg-5">
+                                <h2 class="h3 fw-bolder">Google data access</h2>
+                                <p>The app requests only the Gmail read-only OAuth scope:</p>
+                                <p><code>https://www.googleapis.com/auth/gmail.readonly</code></p>
+                                <ul class="text-muted">
+                                    <li>It does not send, modify, label, archive, or delete email.</li>
+                                    <li>It searches for recent ExponentHR MFA messages and reads only matching results needed for the authentication attempt.</li>
+                                    <li>It does not use Google data for advertising, profiling, or sale.</li>
+                                </ul>
+                                <p class="mb-0">See the <a href="/jasper-timeclock-privacy.html">Privacy Policy</a> for retention, sharing, security, and revocation details.</p>
+                            </div>
+                        </div>
+                        <div class="card shadow border-0 rounded-4">
+                            <div class="card-body p-4 p-lg-5">
+                                <h2 class="h3 fw-bolder">Operator and support</h2>
+                                <p>Jasper Timeclock MFA is operated by Micheal Breedlove for personal use.</p>
+                                <p class="mb-0">Questions: <a href="mailto:mikejohnbreedlove@gmail.com">contact the operator</a>.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+    <footer class="bg-white py-4 mt-auto">
+        <div class="container px-5 d-flex flex-wrap justify-content-between gap-2 small">
+            <span>Copyright &copy; Micheal Breedlove 2026</span>
+            <span><a href="/jasper-timeclock-privacy.html">Privacy</a> &middot; <a href="/jasper-timeclock-terms.html">Terms</a> &middot; <a href="/contact.html">Contact</a></span>
+        </div>
+    </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -11,4 +11,7 @@
   <url><loc>https://www.michealbreedlove.com/case-study-gitops-backups.html</loc><priority>0.7</priority></url>
   <url><loc>https://www.michealbreedlove.com/status.html</loc><priority>0.6</priority></url>
   <url><loc>https://www.michealbreedlove.com/article-sre-pipeline.html</loc><priority>0.7</priority></url>
+  <url><loc>https://www.michealbreedlove.com/jasper-timeclock.html</loc><priority>0.5</priority></url>
+  <url><loc>https://www.michealbreedlove.com/jasper-timeclock-privacy.html</loc><priority>0.4</priority></url>
+  <url><loc>https://www.michealbreedlove.com/jasper-timeclock-terms.html</loc><priority>0.3</priority></url>
 </urlset>


### PR DESCRIPTION
## Summary
- add a public Jasper Timeclock MFA app-information page
- add a Gmail read-only privacy policy and terms page
- link the disclosures from the portfolio footer and sitemap

## Safety
- declares only the existing `gmail.readonly` scope
- states local processing, retention, revocation, and Google Limited Use compliance
- does not include credentials, tokens, or private configuration

## Verification
- static HTML parser and internal-link checks passed
- sitemap parses as valid XML
- `npm run build` passed
- rendered homepage and privacy policy were visually inspected in clean headless Chrome
